### PR TITLE
Don't use dynamic linking by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+dev = "run --features bevy/dynamic_linking"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,6 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eaad7fe854258047680c51c3cacb804468553c04241912f6254c841c67c0198"
 dependencies = [
- "bevy_dylib",
  "bevy_internal",
 ]
 
@@ -241,15 +240,6 @@ dependencies = [
  "bevy_time",
  "bevy_utils",
  "const-fnv1a-hash",
-]
-
-[[package]]
-name = "bevy_dylib"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b2a0773cfe9d27256fba1e5005a14968b34f751c09397ee4e278f0fb235db"
-dependencies = [
- "bevy_internal",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,6 @@ version = "0.15.3"
 default-features = false
 features = ["bevy_state"]
 
-[features]
-default = ["dev"]
-dev = ["bevy/dynamic_linking"]
-
 [lints.clippy]
 too_many_arguments = "allow"
 type_complexity = "allow"


### PR DESCRIPTION
Dynamic linking is great for development, but seems to breaks when installed (via `cargo install`). This could previously be worked around with `cargo install --no-default-features`, but that's the opposite workflow we want.

This change disables dynamic linking by default. An alias has been created that runs `jjj` with dynamic linking enabled (`cargo dev` = `cargo run --features bevy/dynamic-linking`).

Resolves #31 