### PR TITLE
Allow users to configura `jjj` through `jj config`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,8 @@ dependencies = [
  "once_cell",
  "ratatui",
  "regex",
+ "serde",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1656,6 +1658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,10 +1810,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1811,6 +1837,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ ratatui = { version = "0.29.0", features = ["unstable-rendered-line-info"] }
 regex = "1.11.1"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
+serde = { version = "1.0.219", features = ["derive"] }
+toml = "0.8.20"
 
 [dependencies.bevy]
 version = "0.15.3"

--- a/src/backend/config.rs
+++ b/src/backend/config.rs
@@ -1,0 +1,90 @@
+use anyhow::anyhow;
+use bevy::prelude::*;
+use serde::{de::DeserializeOwned, Deserialize};
+
+use super::execute_jj_command;
+
+pub fn plugin(app: &mut App) {
+    app.insert_resource(init_config());
+}
+
+#[tracing::instrument(skip_all)]
+fn init_config() -> Config {
+    let config_toml = execute_jj_command(vec!["config", "list"])
+        .map_err(|e| anyhow!("Failed to read config: {e}"))
+        .unwrap();
+
+    let root = toml::de::from_str::<ConfigRoot>(&config_toml)
+        .map_err(|e| anyhow!("Failed to parse config: {e}"))
+        .unwrap();
+
+    info!("{:?}", &root.jjj);
+
+    root.jjj
+}
+
+#[allow(unused)]
+#[derive(Debug, Deserialize)]
+struct ConfigRoot {
+    #[serde(default = "default_table")]
+    jjj: Config,
+}
+
+fn default_table<De: DeserializeOwned>() -> De {
+    toml::de::from_str::<De>("").unwrap()
+}
+
+/// Application configuration.
+#[derive(Debug, Deserialize, Reflect, Resource)]
+#[serde(rename_all = "kebab-case")]
+pub struct Config {
+    /// Logging configuration.
+    #[serde(default = "default_table")]
+    pub log: LogConfig,
+
+    /// Splash screen configuration.
+    #[serde(default = "default_table")]
+    pub splash: SplashConfig,
+}
+
+/// Configuration for logging.
+#[derive(Debug, Deserialize, Reflect)]
+#[serde(rename_all = "kebab-case")]
+pub struct LogConfig {
+    /// How frequently jjj should check the status of the current repo.
+    #[serde(default = "LogConfig::default_poll_interval_ms")]
+    pub poll_interval_ms: u64,
+}
+
+impl LogConfig {
+    fn default_poll_interval_ms() -> u64 {
+        1000
+    }
+}
+
+/// Configuration for the splash screen.
+#[derive(Debug, Deserialize, Reflect)]
+#[serde(rename_all = "kebab-case")]
+pub struct SplashConfig {
+    /// Whether to skip the splash screen on startup.
+    #[serde(default)]
+    pub skip: bool,
+
+    /// The total max duration the splash screen should be displayed for.
+    #[serde(default = "SplashConfig::default_total_duration_ms")]
+    pub total_duration_ms: u64,
+
+    /// The duration between splash screen animation frames.
+    #[serde(default = "SplashConfig::default_line_interval_ms")]
+    pub line_interval_ms: u64,
+}
+
+impl SplashConfig {
+    fn default_total_duration_ms() -> u64 {
+        1950
+    }
+
+    fn default_line_interval_ms() -> u64 {
+        150
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,13 +5,14 @@ use std::process::Command;
 use anyhow::Result;
 use bevy::prelude::*;
 
+pub mod config;
 pub mod log;
 pub mod poll;
 pub mod revisions;
 
 #[tracing::instrument(skip_all)]
 pub fn plugin(app: &mut App) {
-    app.add_plugins((log::plugin, poll::plugin));
+    app.add_plugins((log::plugin, poll::plugin, config::plugin));
 
     debug!("Finished loading");
 }

--- a/src/backend/poll.rs
+++ b/src/backend/poll.rs
@@ -1,22 +1,20 @@
-use std::{env, time::Duration};
+use std::time::Duration;
 
 use bevy::prelude::*;
-use lazy_static::lazy_static;
 
 use crate::{
     app::AppSet,
     backend::log::{LogResponseEvent, RefreshLogEvent},
     screens::Screen,
-    utils::AppExt,
 };
 
-lazy_static! {
-    static ref POLL_INTERVAL_MS: String = env::var("POLL_INTERVAL_MS").unwrap_or("1000".into());
-}
+use super::config::Config;
 
 #[tracing::instrument(skip_all)]
 pub fn plugin(app: &mut App) {
-    app.register_scoped_type::<PollTimer>(Screen::Interface);
+    app.register_type::<PollTimer>();
+    app.add_systems(OnEnter(Screen::Interface), PollTimer::init);
+    app.add_systems(OnExit(Screen::Interface), PollTimer::remove);
 
     app.add_systems(
         Update,
@@ -36,6 +34,13 @@ pub fn plugin(app: &mut App) {
 struct PollTimer(Timer);
 
 impl PollTimer {
+    fn init(mut commands: Commands, config: Res<Config>) {
+        commands.insert_resource(Self(Timer::new(
+            Duration::from_millis(config.log.poll_interval_ms),
+            TimerMode::Repeating,
+        )));
+    }
+
     fn tick(mut poll_timer: ResMut<Self>, time: Res<Time>) {
         poll_timer.tick(time.delta());
     }
@@ -53,14 +58,8 @@ impl PollTimer {
             break;
         }
     }
-}
 
-impl Default for PollTimer {
-    fn default() -> Self {
-        let interval = (POLL_INTERVAL_MS.parse::<u64>())
-            .expect("POLL_INTERVAL_MS should have been a valid 64 bit integer");
-
-        let duration = Duration::from_millis(interval);
-        Self(Timer::new(duration, TimerMode::Repeating))
+    fn remove(mut commands: Commands) {
+        commands.remove_resource::<Self>();
     }
 }

--- a/src/screens/mod.rs
+++ b/src/screens/mod.rs
@@ -2,18 +2,30 @@
 
 use bevy::prelude::*;
 
+use crate::backend::config::Config;
+
 pub mod interface;
 pub mod splash;
 
 /// Sets up the application screens.
 #[tracing::instrument(skip_all)]
 pub fn plugin(app: &mut App) {
-    app.init_state::<Screen>();
     app.enable_state_scoped_entities::<Screen>();
+    app.init_state::<Screen>();
+
+    app.add_systems(Startup, init_state);
 
     app.add_plugins((splash::plugin, interface::plugin));
 
     debug!("Finished loading");
+}
+
+fn init_state(mut next_state: ResMut<NextState<Screen>>, config: Res<Config>) {
+    next_state.set(if !config.splash.skip {
+        Screen::Splash
+    } else {
+        Screen::Interface
+    });
 }
 
 /// Determines what screen should be shown.

--- a/src/screens/splash.rs
+++ b/src/screens/splash.rs
@@ -12,7 +12,7 @@ use ratatui::{
     widgets::{Clear, Paragraph},
 };
 
-use crate::app::AppSet;
+use crate::{app::AppSet, backend::config::Config};
 
 use super::Screen;
 
@@ -54,12 +54,6 @@ pub fn plugin(app: &mut App) {
 
     debug!("Finished loading");
 }
-
-/// The total max duration the splash screen should be displayed for.
-const SPLASH_DURATION: Duration = Duration::from_millis(1950);
-
-/// The duration between splash screen animation frames.
-const SPLASH_LINE_INTERVAL: Duration = Duration::from_millis(150);
 
 /// The splash screen.
 const SPLASH_LINES: [&str; 8] = [
@@ -134,15 +128,12 @@ impl SplashCursor {
 #[derive(Deref, DerefMut, Reflect, Resource)]
 struct SplashTimer(Timer);
 
-impl Default for SplashTimer {
-    fn default() -> Self {
-        Self(Timer::new(SPLASH_DURATION, TimerMode::Once))
-    }
-}
-
 impl SplashTimer {
-    fn init(mut commands: Commands) {
-        commands.init_resource::<Self>();
+    fn init(mut commands: Commands, config: Res<Config>) {
+        commands.insert_resource(Self(Timer::new(
+            Duration::from_millis(config.splash.total_duration_ms),
+            TimerMode::Once,
+        )));
     }
 
     fn tick(time: Res<Time>, mut timer: ResMut<Self>) {
@@ -164,15 +155,12 @@ impl SplashTimer {
 #[derive(Deref, DerefMut, Reflect, Resource)]
 struct SplashLineTimer(Timer);
 
-impl Default for SplashLineTimer {
-    fn default() -> Self {
-        Self(Timer::new(SPLASH_LINE_INTERVAL, TimerMode::Repeating))
-    }
-}
-
 impl SplashLineTimer {
-    fn init(mut commands: Commands) {
-        commands.init_resource::<Self>();
+    fn init(mut commands: Commands, config: Res<Config>) {
+        commands.insert_resource(Self(Timer::new(
+            Duration::from_millis(config.splash.line_interval_ms),
+            TimerMode::Repeating,
+        )));
     }
 
     fn tick(time: Res<Time>, mut timer: ResMut<Self>) {


### PR DESCRIPTION
This change piggybacks off of jj's configuration stack, with custom fields living at `[jjj]`. Right now this configuration includes the log polling system and the splash screen.

Resolves #25, resolves #26 