### PR TITLE
Fix decorations getting absorbed by graphs

### DIFF
--- a/src/backend/log.rs
+++ b/src/backend/log.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::hashbrown::HashMap};
 use regex::{Captures, Match, Regex};
 
 use crate::{
@@ -19,7 +19,22 @@ pub struct RefreshLogEvent;
 pub struct LogRevsetEvent(pub String);
 
 #[derive(Event, Deref, DerefMut)]
-pub struct LogResponseEvent(pub Vec<Revision>);
+pub struct LogResponseEvent(pub Vec<LogOutput>);
+
+#[derive(Clone)]
+pub enum LogOutput {
+    Revision(Revision),
+    Decoration(String),
+}
+
+impl LogOutput {
+    pub fn revision(&self) -> Option<Revision> {
+        match self {
+            Self::Revision(revision) => Some(revision.clone()),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Default, Deref, DerefMut, Reflect, Resource)]
 pub struct CurrentRevset(pub Option<String>);
@@ -38,6 +53,102 @@ pub fn plugin(app: &mut App) {
     );
 
     trace!("Plugin initialized.");
+}
+
+#[tracing::instrument(skip_all)]
+fn refresh_log(
+    mut ev_refresh_log: EventReader<RefreshLogEvent>,
+    mut ev_log_revset: EventWriter<LogRevsetEvent>,
+    current_revset: Res<CurrentRevset>,
+) {
+    for _ in ev_refresh_log.read() {
+        if let Some(revset) = current_revset.0.clone() {
+            ev_log_revset.send(LogRevsetEvent(revset));
+        }
+    }
+}
+
+#[tracing::instrument(skip_all)]
+fn read_logs(
+    mut ev_notification: EventWriter<NotificationEvent>,
+    mut ev_log_response: EventWriter<LogResponseEvent>,
+    mut ev_log_revset: EventReader<LogRevsetEvent>,
+    mut current_revset: ResMut<CurrentRevset>,
+) -> Result<()> {
+    for LogRevsetEvent(revset) in ev_log_revset.read() {
+        debug!("Reading log for revset: {revset}");
+
+        let details =
+            execute_jj_command(vec!["log", "-r", revset.as_str(), "-T", DETAILS_TEMPLATE])
+                .map_err(|_| anyhow!("Couldn't read log for revset `{revset}`"))?;
+
+        let descriptions = get_descriptions(revset)?;
+
+        let mut detail_lines = details.lines().peekable();
+        let mut results = vec![];
+
+        'parse: loop {
+            // Stop at the end of the iterator
+            let Some(line_one) = detail_lines.next() else {
+                break 'parse;
+            };
+
+            // We shouldn't encounter empty lines in Jujutsu's output, but this should prevent any
+            // catastrophic failure.
+            if line_one.trim().is_empty() {
+                continue;
+            }
+
+            debug!("{line_one}");
+
+            match detail_lines.peek() {
+                Some(line_two) => {
+                    let lines = format!("{line_one}\n{line_two}");
+                    match parse_details(lines.as_str())? {
+                        // This is a real revision, merge the details with the optional description
+                        // and push it.
+                        Some(details) => {
+                            let description = descriptions.get(&details.change_id.0).cloned();
+                            results.push(LogOutput::Revision(Revision {
+                                is_divergent: details.is_divergent,
+                                is_immutable: details.is_immutable,
+                                bookmarks: details.bookmarks,
+                                change_id: details.change_id,
+                                commit_id: details.commit_id,
+                                timestamp: details.timestamp,
+                                is_empty: details.is_empty,
+                                is_root: details.is_root,
+                                author: details.author,
+                                graph: details.graph,
+                                description,
+                            }));
+
+                            // We've verified the next line is part of the revision, so consume it.
+                            let _ = detail_lines.next();
+                        }
+
+                        // No match means this isn't a revision and we can
+                        // treat it as a decoration.
+                        None => results.push(LogOutput::Decoration(line_one.to_string())),
+                    }
+                }
+
+                // No extra line means we're at the end of the graph and this is a decoration.
+                None => results.push(LogOutput::Decoration(line_one.to_string())),
+            }
+        }
+
+        if !results.is_empty() {
+            ev_log_response.send(LogResponseEvent(results));
+            current_revset.0 = Some(revset.clone());
+        } else {
+            ev_notification.send(NotificationEvent::angry(format!(
+                "No revisions found for `{revset}`"
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 const DETAILS_TEMPLATE: &str = concat!(
@@ -79,8 +190,68 @@ const MATCH_DETAILS: &str = concat!(
             r#"(?P<root>.*)"#
         ]
     ),
-    r#"\]\n(?P<graph_tail>.*?)$"#,
+    r#"\]\n(?P<graph_tail>.*?)%JJJ%$"#,
 );
+
+struct Details {
+    change_id: ChangeId,
+    commit_id: CommitId,
+    is_divergent: bool,
+    is_immutable: bool,
+    is_empty: bool,
+    is_root: bool,
+    graph: Parts<String>,
+    author: String,
+    timestamp: String,
+    bookmarks: Vec<String>,
+}
+
+fn parse_details(lines: &str) -> Result<Option<Details>> {
+    let Some(details_caps) = Regex::new(MATCH_DETAILS)?.captures(lines) else {
+        return Ok(None);
+    };
+
+    let change_id = require(&details_caps, "change_id")?.as_str().to_string();
+    let change_id_shortest = require(&details_caps, "change_id_shortest")?.as_str().len();
+
+    let commit_id = require(&details_caps, "commit_id")?.as_str().to_string();
+    let commit_id_shortest = require(&details_caps, "commit_id_shortest")?.as_str().len();
+
+    let author = require(&details_caps, "author")?.as_str().to_string();
+    let timestamp = require(&details_caps, "timestamp")?.as_str().to_string();
+
+    let bookmarks = (details_caps.name("bookmarks"))
+        .map(|d| {
+            (d.as_str().trim().split(" "))
+                .map(String::from)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let is_divergent = require(&details_caps, "divergent")?.as_str() == "true";
+    let is_immutable = require(&details_caps, "immutable")?.as_str() == "true";
+    let is_empty = require(&details_caps, "empty")?.as_str() == "true";
+    let is_root = require(&details_caps, "root")?.as_str() == "true";
+
+    let graph_head = require(&details_caps, "graph_head")?.as_str().to_string();
+    let graph_tail = require(&details_caps, "graph_tail")?.as_str().to_string();
+
+    Ok(Some(Details {
+        change_id: ChangeId(change_id, change_id_shortest),
+        commit_id: CommitId(commit_id, commit_id_shortest),
+        graph: Parts {
+            head: graph_head,
+            tail: graph_tail,
+        },
+        is_divergent,
+        is_immutable,
+        is_empty,
+        is_root,
+        author,
+        timestamp,
+        bookmarks,
+    }))
+}
 
 const DESCRIPTION_TEMPLATE: &str = concat!(
     "'[' ++ ",
@@ -97,127 +268,42 @@ const MATCH_DESCRIPTION: &str = concat!(
     r#"\]"#,
 );
 
-#[tracing::instrument(skip_all)]
-fn refresh_log(
-    mut ev_refresh_log: EventReader<RefreshLogEvent>,
-    mut ev_log_revset: EventWriter<LogRevsetEvent>,
-    current_revset: Res<CurrentRevset>,
-) {
-    for _ in ev_refresh_log.read() {
-        if let Some(revset) = current_revset.0.clone() {
-            ev_log_revset.send(LogRevsetEvent(revset));
-        }
-    }
-}
+fn get_descriptions(revset: &str) -> Result<HashMap<String, String>> {
+    let response = execute_jj_command(vec![
+        "log",
+        "--no-graph",
+        "-r",
+        revset,
+        "-T",
+        DESCRIPTION_TEMPLATE,
+    ])
+    .map_err(|_| anyhow!("Couldn't read log for revset `{revset}`"))?;
 
-#[tracing::instrument(skip_all)]
-fn read_logs(
-    mut ev_notification: EventWriter<NotificationEvent>,
-    mut ev_log_response: EventWriter<LogResponseEvent>,
-    mut ev_log_revset: EventReader<LogRevsetEvent>,
-    mut current_revset: ResMut<CurrentRevset>,
-) -> Result<()> {
-    for LogRevsetEvent(revset) in ev_log_revset.read() {
-        debug!("Reading log for revset: {revset}");
-
-        let details =
-            execute_jj_command(vec!["log", "-r", revset.as_str(), "-T", DETAILS_TEMPLATE])
-                .map_err(|_| anyhow!("Couldn't read log for revset `{revset}`"))?;
-
-        let descriptions = execute_jj_command(vec![
-            "log",
-            "--no-graph",
-            "-r",
-            revset.as_str(),
-            "-T",
-            DESCRIPTION_TEMPLATE,
-        ])
-        .map_err(|_| anyhow!("Couldn't read log for revset `{revset}`"))?;
-
-        let mut revs = vec![];
-        for line in (details.split("%JJJ%\n").zip(descriptions.split("%JJJ%")))
-            .filter(|(a, b)| !a.trim().is_empty() && !b.trim().is_empty())
-            .map(parse_line)
-            .filter_map(|l| l.transpose())
-        {
-            revs.push(line?);
-        }
-
-        if !revs.is_empty() {
-            ev_log_response.send(LogResponseEvent(revs));
-            current_revset.0 = Some(revset.clone());
-        } else {
-            ev_notification.send(NotificationEvent::angry(format!(
-                "No revisions found for `{revset}`"
-            )));
-        }
+    let mut map = HashMap::new();
+    for line in response.split("%JJJ%") {
+        let Some((change_id, description)) = parse_description(line)? else {
+            continue;
+        };
+        map.insert(change_id, description);
     }
 
-    Ok(())
+    Ok(map)
 }
 
-fn parse_line((details_line, description_line): (&str, &str)) -> Result<Option<Revision>> {
-    let Some(details_caps) = Regex::new(MATCH_DETAILS)?.captures(details_line) else {
+#[tracing::instrument]
+fn parse_description(line: &str) -> Result<Option<(String, String)>> {
+    let Some(caps) = Regex::new(MATCH_DESCRIPTION)?.captures(line) else {
         return Ok(None);
     };
 
-    let Some(description_caps) = Regex::new(MATCH_DESCRIPTION)?.captures(description_line) else {
-        return Ok(None);
-    };
-
-    let change_id = require(&details_caps, "change_id")?.as_str().to_string();
-    let change_id_shortest = require(&details_caps, "change_id_shortest")?.as_str().len();
-
-    // These lines should always match for the same revset.
-    assert_eq!(
-        change_id,
-        require(&description_caps, "change_id")?
-            .as_str()
-            .to_string()
-    );
-
-    let commit_id = require(&details_caps, "commit_id")?.as_str().to_string();
-    let commit_id_shortest = require(&details_caps, "commit_id_shortest")?.as_str().len();
-
-    let author = require(&details_caps, "author")?.as_str().to_string();
-    let timestamp = require(&details_caps, "timestamp")?.as_str().to_string();
-
-    let bookmarks = (details_caps.name("bookmarks"))
-        .map(|d| {
-            (d.as_str().trim().split(" "))
-                .map(String::from)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-
-    let description = (description_caps.name("description"))
-        .map(|d| d.as_str().trim().to_string())
+    let change_id = require(&caps, "change_id")?.as_str().to_string();
+    let description = (caps.name("description"))
+        .map(|c| c.as_str().trim().to_string())
         .filter(|d| !d.is_empty());
 
-    let is_divergent = require(&details_caps, "divergent")?.as_str() == "true";
-    let is_immutable = require(&details_caps, "immutable")?.as_str() == "true";
-    let is_empty = require(&details_caps, "empty")?.as_str() == "true";
-    let is_root = require(&details_caps, "root")?.as_str() == "true";
+    trace!(change_id, description);
 
-    let graph_head = require(&details_caps, "graph_head")?.as_str().to_string();
-    let graph_tail = require(&details_caps, "graph_tail")?.as_str().to_string();
-
-    Ok(Some(Revision {
-        change_id: ChangeId(change_id, change_id_shortest),
-        commit_id: CommitId(commit_id, commit_id_shortest),
-        graph: Parts {
-            head: graph_head,
-            tail: graph_tail,
-        },
-        is_divergent,
-        is_immutable,
-        description,
-        is_empty,
-        is_root,
-        author,
-        timestamp,
-        bookmarks,
-    }))
+    Ok(Some(change_id).zip(description))
 }
 
 fn require<'a>(caps: &Captures<'a>, name: &str) -> Result<Match<'a>> {

--- a/src/frontend/change_buffer.rs
+++ b/src/frontend/change_buffer.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use bevy::prelude::*;
 use bevy_ratatui::event::KeyEvent;
 use crossterm::event::{KeyCode, KeyEventKind};
@@ -7,7 +8,7 @@ use ratatui::{
 };
 
 use crate::backend::{
-    log::LogResponseEvent,
+    log::{LogOutput, LogResponseEvent},
     revisions::{ChangeId, CommitId, Revision},
 };
 
@@ -38,6 +39,7 @@ pub struct ChangeBufferSelectionEvent(pub RevisionSelection);
 #[derive(Clone, Component, Default)]
 pub struct ChangeBuffer {
     revisions: Vec<Revision>,
+    log_output: Vec<LogOutput>,
     selection: IndexSelection,
     pub viewport_y: usize,
 }
@@ -140,10 +142,13 @@ fn read_revisions(
 ) -> Result<()> {
     let mut change_buffer = change_buffer.get_single_mut()?;
 
-    for LogResponseEvent(revisions) in ev_log_response.read() {
-        if change_buffer.revisions.is_empty() {
+    for LogResponseEvent(log_output) in ev_log_response.read() {
+        let revisions = log_output.iter().filter_map(LogOutput::revision).collect();
+
+        if change_buffer.log_output.is_empty() {
             change_buffer.selection = IndexSelection::Single(0);
-            change_buffer.revisions = revisions.clone();
+            change_buffer.log_output = log_output.clone();
+            change_buffer.revisions = revisions;
             continue;
         }
 
@@ -156,7 +161,8 @@ fn read_revisions(
                     .unwrap_or(0);
 
                 change_buffer.selection = IndexSelection::Single(index);
-                change_buffer.revisions = revisions.clone();
+                change_buffer.log_output = log_output.clone();
+                change_buffer.revisions = revisions;
             }
 
             // Select the range of commits with the same start and end change_id if they exist
@@ -169,7 +175,9 @@ fn read_revisions(
                     .zip((revisions.iter()).position(|r| r.change_id.0 == *end_change_id.0))
                     .map(|(start, end)| IndexSelection::Range(start, end))
                     .unwrap_or(IndexSelection::Single(0));
-                change_buffer.revisions = revisions.clone();
+
+                change_buffer.log_output = log_output.clone();
+                change_buffer.revisions = revisions;
             }
         }
 
@@ -193,18 +201,47 @@ impl StatefulWidget for ChangeBuffer {
     type State = usize;
 
     fn render(self, area: Rect, buf: &mut Buffer, viewport_y: &mut Self::State) {
-        let selected_revs = match self.selection {
-            IndexSelection::Single(index) => index..=index,
-            IndexSelection::Range(start, end) => start..=end,
+        let map_index = |i: usize| {
+            if self.revisions.is_empty() {
+                return 0..=0;
+            }
+
+            let revision = &self.revisions[i];
+            let line_index = (self.log_output.iter())
+                .position(|l| {
+                    l.revision()
+                        .is_some_and(|r| r.change_id.0 == revision.change_id.0)
+                })
+                .ok_or_else(|| {
+                    anyhow!("Couldn't map revision to log line. This should never happen.")
+                })
+                .unwrap();
+
+            line_index..=line_index
         };
 
-        let lines = (self.revisions.iter().enumerate())
-            .flat_map(|(i, rev)| RevisionLine::vec_from(rev, selected_revs.contains(&i)))
-            .collect::<Vec<_>>();
+        let selected_lines = match self.selection {
+            IndexSelection::Single(index) => map_index(index),
+            IndexSelection::Range(start, end) => {
+                map_index(start).start().clone()..=map_index(end).end().clone()
+            }
+        };
+
+        let mut lines = vec![];
+        let mut last_selected_index = 0;
+
+        for (i, item) in self.log_output.iter().enumerate() {
+            let is_selected = selected_lines.contains(&i);
+            lines.append(&mut LogLine::vec_from(item, is_selected));
+
+            if is_selected {
+                last_selected_index = lines.len() - 1;
+            }
+        }
 
         let (computed_viewport_y, line_range) = viewport::compute_sliding_window(
             lines.len(),
-            2 * selected_revs.end(),
+            last_selected_index,
             *viewport_y,
             area.height as usize,
             area.height as usize / 4,
@@ -228,6 +265,44 @@ impl StatefulWidget for ChangeBuffer {
         }
 
         EmptyBuffer.render(empty, buf);
+    }
+}
+
+#[derive(Clone)]
+enum LogLine {
+    Revision(RevisionLine),
+    Decoration(DecorationLine),
+}
+
+impl LogLine {
+    fn vec_from(log_output: &LogOutput, is_selected: bool) -> Vec<Self> {
+        match log_output {
+            LogOutput::Decoration(text) => {
+                vec![Self::Decoration(DecorationLine {
+                    text: text.clone(),
+                    is_selected,
+                })]
+            }
+            LogOutput::Revision(revision) => RevisionLine::vec_from(&revision, is_selected)
+                .into_iter()
+                .map(|l| Self::Revision(l))
+                .collect(),
+        }
+    }
+}
+
+impl Widget for LogLine {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        match self {
+            Self::Decoration(decoration) => decoration.render(area, buf),
+            Self::Revision(revision) => match revision {
+                RevisionLine::Top(top) => top.render(area, buf),
+                RevisionLine::Bottom(bottom) => bottom.render(area, buf),
+            },
+        }
     }
 }
 
@@ -258,18 +333,6 @@ impl RevisionLine {
                 is_selected,
             }),
         ]
-    }
-}
-
-impl Widget for RevisionLine {
-    fn render(self, area: Rect, buf: &mut Buffer)
-    where
-        Self: Sized,
-    {
-        match self {
-            RevisionLine::Top(top) => top.render(area, buf),
-            RevisionLine::Bottom(bottom) => bottom.render(area, buf),
-        }
     }
 }
 
@@ -381,5 +444,26 @@ impl Widget for RevisionBottomLine {
         }
 
         bottom.render(area, buf);
+    }
+}
+
+#[derive(Clone)]
+struct DecorationLine {
+    text: String,
+    is_selected: bool,
+}
+
+impl Widget for DecorationLine {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        if self.is_selected {
+            Block::default()
+                .style(Style::new().on_dark_gray())
+                .render(area, buf)
+        }
+
+        Span::styled(format!("  {}", self.text), Style::new().dim()).render(area, buf);
     }
 }

--- a/src/frontend/viewport.rs
+++ b/src/frontend/viewport.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+#[tracing::instrument]
 pub fn compute_sliding_window(
     item_length: usize,
     selection: usize,
@@ -16,6 +17,12 @@ pub fn compute_sliding_window(
     } else {
         viewport_y
     };
+
+    tracing::trace!(
+        computed_y,
+        "{:?}",
+        computed_y..usize::min(item_length, computed_y + viewport_height),
+    );
 
     (
         computed_y,


### PR DESCRIPTION
Decorations will now be properly rendered between commits:

![image](https://github.com/user-attachments/assets/c5e36ac3-1217-49f4-8ed0-d64d62077bcd)
![image](https://github.com/user-attachments/assets/c7d3caf1-5cc9-4f2f-9c0a-d331a47c9e52)

Resolves #62 