### PR TITLE
Remove dependency on nightly toolchain

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -44,10 +44,11 @@ pub fn install() {
 
     subscriber.init();
 
-    panic::update_hook(move |prev, info| {
+    let prev = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
         dump();
         prev(info);
-    });
+    }));
 }
 
 /// Dumps logged messages to the standard output.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(panic_update_hook)]
-
 pub mod app;
 pub mod backend;
 pub mod cli;


### PR DESCRIPTION
This was done originally to let us use `std::panic::update_hook`, but it turns out that function's just a shorthand for using `std::panic::take_hook` and `std::panic::set_hook` in succession, so to let people install `jjj` without nightly we're just gonna do the latter.