### PR TITLE
feat: allow defining overriding and removing keyboard shortcuts

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use bevy::{app::ScheduleRunnerPlugin, prelude::*, state::app::StatesPlugin};
 use bevy_ratatui::RatatuiPlugins;
 
-use crate::{backend, events, frontend, screens};
+use crate::{backend, commands, events, frontend, screens};
 
 #[mutants::skip]
 #[tracing::instrument(skip_all)]
@@ -33,6 +33,7 @@ pub fn plugin(app: &mut App) {
 
     app.add_plugins((
         events::plugin,
+        commands::plugin,
         screens::plugin,
         frontend::plugin,
         backend::plugin,

--- a/src/backend/config.rs
+++ b/src/backend/config.rs
@@ -1,6 +1,10 @@
+use std::{collections::HashMap, ops::Deref};
+
 use anyhow::anyhow;
 use bevy::prelude::*;
-use serde::{de::DeserializeOwned, Deserialize};
+use serde::{de::DeserializeOwned, Deserialize, Deserializer};
+
+use crate::commands::{Command, StaticCommand};
 
 use super::JujutsuCli;
 
@@ -25,7 +29,7 @@ fn default_table<De: DeserializeOwned>() -> De {
 }
 
 /// Application configuration.
-#[derive(Debug, Deserialize, PartialEq, Eq, Reflect, Resource)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Resource)]
 pub struct Config {
     /// Logging configuration.
     #[serde(default = "default_table")]
@@ -34,6 +38,10 @@ pub struct Config {
     /// Splash screen configuration.
     #[serde(default = "default_table")]
     pub splash: SplashConfig,
+
+    /// Key bindings
+    #[serde(default = "default_table")]
+    pub keys: KeysConfig,
 }
 
 impl FromWorld for Config {
@@ -61,7 +69,7 @@ impl Config {
 }
 
 /// Configuration for logging.
-#[derive(Debug, Deserialize, PartialEq, Eq, Reflect)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 pub struct LogConfig {
     /// How frequently jjj should check the status of the current repo.
     #[serde(default = "LogConfig::default_poll_interval_ms")]
@@ -76,7 +84,7 @@ impl LogConfig {
 }
 
 /// Configuration for the splash screen.
-#[derive(Debug, Deserialize, PartialEq, Eq, Reflect)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 pub struct SplashConfig {
     /// Whether to skip the splash screen on startup.
     #[serde(default)]
@@ -100,6 +108,90 @@ impl SplashConfig {
     #[mutants::skip]
     fn default_line_interval_ms() -> u64 {
         150
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+pub struct KeysConfig {
+    #[serde(deserialize_with = "KeysConfig::change_keymap")]
+    #[serde(default = "default_change_keymap")]
+    pub change: KeyMap,
+    #[serde(deserialize_with = "KeysConfig::command_keymap")]
+    #[serde(default = "default_command_keymap")]
+    pub command: KeyMap,
+}
+
+const DEFAULT_CHANGE_KEYMAP: &str = r#"
+j = "move_visual_line_down"
+k = "move_visual_line_up"
+x = "extend_line_up"
+"#;
+
+fn default_change_keymap() -> KeyMap {
+    toml::de::from_str(DEFAULT_CHANGE_KEYMAP).unwrap()
+}
+
+// TODO: default command binding?
+// TODO: use raw string literal when the becomes nonempty.
+const DEFAULT_COMMAND_KEYMAP: &str = "";
+
+fn default_command_keymap() -> KeyMap {
+    toml::de::from_str(DEFAULT_COMMAND_KEYMAP).unwrap()
+}
+
+impl KeysConfig {
+    fn change_keymap<'de, D>(deserializer: D) -> Result<KeyMap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let final_keymap =
+            KeyMap::merge(default_change_keymap(), KeyMap::deserialize(deserializer)?);
+
+        Ok(final_keymap)
+    }
+
+    fn command_keymap<'de, D>(deserializer: D) -> Result<KeyMap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let final_keymap =
+            KeyMap::merge(default_command_keymap(), KeyMap::deserialize(deserializer)?);
+
+        Ok(final_keymap)
+    }
+}
+
+impl KeyMap {
+    fn merge(lhs: KeyMap, rhs: KeyMap) -> KeyMap {
+        let mut final_keymap = lhs;
+
+        final_keymap.0.extend(rhs.0);
+
+        final_keymap
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+pub struct KeyMap(HashMap<char, KeyDefinition>);
+
+impl Deref for KeyMap {
+    type Target = HashMap<char, KeyDefinition>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum KeyDefinition {
+    Command(Command),
+    // TODO: minor mode
+}
+
+impl From<StaticCommand> for KeyDefinition {
+    fn from(static_command: StaticCommand) -> Self {
+        KeyDefinition::Command(Command::Static(static_command))
     }
 }
 
@@ -127,6 +219,9 @@ mod tests {
                 jjj.log.poll_interval_ms = 123
                 jjj.splash.skip = true
                 jjj.splash.total_duration_ms = 4567
+                jjj.keys.change.h = "move_visual_line_down"
+                jjj.keys.change.t = "move_visual_line_up"
+                jjj.keys.change.x = "move_visual_line_up"
             "#
             .into())
         }));
@@ -143,6 +238,19 @@ mod tests {
                     total_duration_ms: 4567,
                     ..default_table()
                 },
+                keys: KeysConfig {
+                    change: KeyMap(HashMap::from_iter([
+                        // Added shortcuts
+                        ('h', StaticCommand::MoveVisualLineDown.into()),
+                        ('t', StaticCommand::MoveVisualLineUp.into()),
+                        // Default shortcuts
+                        ('j', StaticCommand::MoveVisualLineDown.into()),
+                        ('k', StaticCommand::MoveVisualLineUp.into()),
+                        // Overridden shortcuts
+                        ('x', StaticCommand::MoveVisualLineUp.into()),
+                    ])),
+                    command: KeyMap(HashMap::new()),
+                }
             })
         );
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,32 @@
+use bevy::prelude::*;
+use serde::Deserialize;
+
+pub fn plugin(_app: &mut App) {}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Event, PartialEq)]
+#[serde(untagged)]
+pub enum Command {
+    Static(StaticCommand),
+    // TODO: typable commands
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum StaticCommand {
+    /// Selects the line below the current selection.
+    MoveVisualLineDown,
+
+    /// Selects the line above the current selection.
+    MoveVisualLineUp,
+
+    /// Extends the current selection to include the next line down.
+    ExtendLineDown,
+
+    /// Extends the current selection to include the next line up.
+    ExtendLineUp,
+
+    /// Does nothing. Allows to delete a binding.
+    #[serde(alias = "no_op")]
+    #[serde(alias = "noop")]
+    NoOp,
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,6 +3,7 @@ use prelude::*;
 
 pub mod prelude {
     pub use crate::backend::log::{LogResponseEvent, LogRevsetEvent, RefreshLogEvent};
+    pub use crate::commands::Command;
     pub use crate::errors::ErrorEvent;
     pub use crate::frontend::change_buffer::ChangeBufferSelectionEvent;
     pub use crate::frontend::command_line::NotificationEvent;
@@ -14,6 +15,7 @@ pub fn plugin(app: &mut App) {
 
     // Application-wide events
     app.add_event::<ErrorEvent>();
+    app.add_event::<prelude::Command>();
 
     // Backend events
     app.add_event::<RefreshLogEvent>();

--- a/src/frontend/change_buffer.rs
+++ b/src/frontend/change_buffer.rs
@@ -7,9 +7,13 @@ use ratatui::{
     widgets::Block,
 };
 
-use crate::backend::{
-    log::{LogOutput, LogResponseEvent},
-    revisions::{ChangeId, CommitId, Revision},
+use crate::{
+    backend::{
+        config::{Config, KeyDefinition},
+        log::{LogOutput, LogResponseEvent},
+        revisions::{ChangeId, CommitId, Revision},
+    },
+    commands::{Command, StaticCommand},
 };
 
 use super::prelude::*;
@@ -64,12 +68,25 @@ pub enum RevisionSelection {
     Range(Revision, Revision),
 }
 
+fn resolve_command(config: &Config, key: char) -> Option<Command> {
+    config
+        .keys
+        .change
+        .get(&key)
+        .map(|key_def| {
+            let KeyDefinition::Command(command) = key_def;
+            command
+        })
+        .copied()
+}
+
 fn read_keys(
     mut ev_selection: EventWriter<ChangeBufferSelectionEvent>,
     mut change_buffer: Query<&mut ChangeBuffer>,
     mut ev_keypresses: EventReader<KeyEvent>,
     mut exit: EventWriter<AppExit>,
     mut navigation: Navigation,
+    config: Res<Config>,
 ) -> Result<()> {
     let mut change_buffer = change_buffer.get_single_mut()?;
 
@@ -93,28 +110,65 @@ fn read_keys(
                 exit.send_default();
                 return Ok(());
             }
-            (IndexSelection::Single(i), KeyCode::Char('j')) => {
-                Some(IndexSelection::Single(usize::min(i + 1, max)))
-            }
-            (IndexSelection::Single(i), KeyCode::Char('k')) => {
-                Some(IndexSelection::Single(i.saturating_sub(1)))
-            }
-            (IndexSelection::Single(i), KeyCode::Char('x')) => {
-                if i != (i + 1).clamp(0, max) {
-                    Some(IndexSelection::Range(i, usize::min(i + 1, max)))
-                } else {
-                    Some(IndexSelection::Single(i))
+
+            (IndexSelection::Single(i), KeyCode::Char(key)) => {
+                match resolve_command(&config, key) {
+                    Some(Command::Static(StaticCommand::MoveVisualLineDown)) => {
+                        Some(IndexSelection::Single(usize::min(i + 1, max)))
+                    }
+
+                    Some(Command::Static(StaticCommand::MoveVisualLineUp)) => {
+                        Some(IndexSelection::Single(usize::min(i.wrapping_sub(1), max)))
+                    }
+
+                    Some(Command::Static(StaticCommand::ExtendLineDown)) => {
+                        if i != (i + 1).clamp(0, max) {
+                            Some(IndexSelection::Range(i, usize::min(i + 1, max)))
+                        } else {
+                            Some(IndexSelection::Single(i))
+                        }
+                    }
+
+                    Some(Command::Static(StaticCommand::ExtendLineUp)) => {
+                        if i != 0 {
+                            Some(IndexSelection::Range(i - 1, i))
+                        } else {
+                            Some(IndexSelection::Single(i))
+                        }
+                    }
+
+                    Some(Command::Static(StaticCommand::NoOp)) => None,
+
+                    None => None,
                 }
             }
-            (IndexSelection::Range(_, end), KeyCode::Char('j')) => {
-                Some(IndexSelection::Single(usize::min(end + 1, max)))
+
+            (IndexSelection::Range(start, end), KeyCode::Char(key)) => {
+                match resolve_command(&config, key) {
+                    Some(Command::Static(StaticCommand::MoveVisualLineDown)) => {
+                        Some(IndexSelection::Single(usize::min(end + 1, max)))
+                    }
+
+                    Some(Command::Static(StaticCommand::MoveVisualLineUp)) => {
+                        Some(IndexSelection::Single(start.saturating_sub(1)))
+                    }
+
+                    Some(Command::Static(StaticCommand::ExtendLineDown)) => {
+                        Some(IndexSelection::Range(start, usize::min(end + 1, max)))
+                    }
+
+                    Some(Command::Static(StaticCommand::ExtendLineUp)) => {
+                        // TODO: I had a long day at work today - I have exactly zero clue what
+                        // should be written here.
+                        None
+                    }
+
+                    Some(Command::Static(StaticCommand::NoOp)) => None,
+
+                    None => None,
+                }
             }
-            (IndexSelection::Range(start, _), KeyCode::Char('k')) => {
-                Some(IndexSelection::Single(start.saturating_sub(1)))
-            }
-            (IndexSelection::Range(start, end), KeyCode::Char('x')) => {
-                Some(IndexSelection::Range(start, usize::min(end + 1, max)))
-            }
+
             _ => None,
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod backend;
 pub mod cli;
+pub mod commands;
 pub mod errors;
 pub mod events;
 pub mod frontend;


### PR DESCRIPTION
Part of #95.

The title says everything. The implementation is a bit primitive and many things are missing, but that's something we can iterate on :)

For what it's worth, here's the content of my `.jj/repo/config.toml` now:

```toml
[jjj.keys.change]
t = "move_visual_line_up"
h = "move_visual_line_down"
H = "extend_line_down"
j = "noop"
k = "noop"
```

I cherry-picked commit 59fd3465 which written by you (@icorbrey) and started working over it. I removed some things that were too complicated for a first MR. If that's ok for you, we could tackle them later.

For what it's worth, my experience with Bevy is exactly 0, so please report anything that does not look correct.